### PR TITLE
Add single-file output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ output:
   location: './output/'
 ````
 
+### Output types
+
+`output.type` controls how dumps are written:
+
+* `multi_file`: one `.sql` file per table inside `location` (a directory).
+* `file`: every table is written into a single file. Without `naming` the file is `{location}.sql`; with `naming` the templated name (with `[table_name]` dropped) is placed in the directory of `location`. The file is recreated on each run.
+
 ### Configuration Schema
 
 The configuration schema can be found [here](redactdump/core/config.py)

--- a/redactdump/app.py
+++ b/redactdump/app.py
@@ -122,10 +122,6 @@ class RedactDump:
         """Run the redactdump application."""
         tables = self.database.get_tables()
 
-        if self.config["output"]["type"] == "file":
-            self.console.print("[red]Single file not supported with multiple tables. (Maybe later...)[/red]")
-            sys.exit(1)
-
         if not tables:
             self.console.print("[red]No tables found[/red]")
             sys.exit(1)

--- a/redactdump/core/file.py
+++ b/redactdump/core/file.py
@@ -1,6 +1,8 @@
 import os
+import re
+import threading
 from datetime import datetime, timezone
-from typing import List, Union
+from typing import List, Optional, Union
 
 from rich.console import Console
 
@@ -19,8 +21,34 @@ class File:
         """
         self.config = config
         self.console = console
+        self.lock = threading.Lock()
+
+        output = self.config["output"]
+        self.file_path: Optional[str] = self.resolve_file_path(output) if output["type"] == "file" else None
 
         self.create_output_locations()
+
+    @staticmethod
+    def resolve_file_path(output: dict) -> str:
+        """Resolve the path of the single output file.
+
+        Without a naming template the file is {location}.sql. With one, [timestamp]
+        is substituted and [table_name] dropped (a single file spans every table);
+        the templated name is placed in the directory of location.
+
+        Args:
+            output (dict): Output configuration.
+
+        Returns:
+            str: Path to the single output file.
+        """
+        if "naming" not in output:
+            return f"{output['location']}.sql"
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d-%H-%M-%S")
+        name = output["naming"].replace("[table_name]", "").replace("[timestamp]", timestamp)
+        name = re.sub(r"([-_])[-_]+", r"\1", name).strip("-_")
+        directory = os.path.dirname(output["location"])
+        return os.path.join(directory, f"{name}.sql") if directory else f"{name}.sql"
 
     def create_output_locations(self) -> None:
         """Create output locations."""
@@ -28,15 +56,12 @@ class File:
             self.console.print("[cyan]DEBUG: Checking output locations...[/cyan]")
 
         output = self.config["output"]
-        if output["type"] == "file":
-            if not os.path.isfile(f"{output['location']}.sql"):
-                open(f"{output['location']}.sql", "a").close()
-                if self.config["debug"]["enabled"]:
-                    self.console.print(f"[cyan]DEBUG: Created file: {output['location']}.sql[/cyan]")
-            else:
-                # Emtpy file
-                if self.config["debug"]["enabled"]:
-                    self.console.print(f"[cyan]DEBUG: File already exists: {output['location']}.sql[/cyan]")
+        if output["type"] == "file" and self.file_path is not None:
+            os.makedirs(os.path.dirname(self.file_path) or ".", exist_ok=True)
+            with open(self.file_path, "w"):
+                pass
+            if self.config["debug"]["enabled"]:
+                self.console.print(f"[cyan]DEBUG: Created file: {self.file_path}[/cyan]")
         elif output["type"] == "multi_file" and not os.path.isdir(output["location"]):
             prev_folder = "."
             for folder in output["location"].split("/"):
@@ -73,6 +98,29 @@ class File:
             name = f"{table.name}-{time.strftime('%Y-%m-%d-%H-%M-%S')}.sql"
         return name
 
+    @staticmethod
+    def insert_statement(table: Table, row: List[TableColumn]) -> str:
+        """Build an INSERT statement for a single row.
+
+        Args:
+            table (Table): Table.
+            row (List[TableColumn]): Columns of the row.
+
+        Returns:
+            str: The INSERT statement.
+        """
+        values = []
+        for column in row:
+            if column.data_type in ["bigint", "integer", "smallint", "double precision", "numeric"]:
+                values.append(str(column.value))
+            elif column.data_type in ["bit", "bit varying"]:
+                values.append(f"b'{column.value}'")
+            else:
+                values.append(f"'{column.value}'")
+
+        columns = '"' + '", "'.join([column.name for column in row]) + '"'
+        return f"INSERT INTO {table.name} ({columns}) VALUES ({', '.join(values)});"
+
     def write_to_file(self, table: Table, rows: List[List[TableColumn]]) -> Union[str, None]:
         """Write data to file.
 
@@ -88,22 +136,11 @@ class File:
             name = self.get_name(output, table)
             with open(f"{output['location']}/{name}", "a") as file:
                 for row in rows:
-                    values = []
-                    for column in row:
-                        if column.data_type in [
-                            "bigint",
-                            "integer",
-                            "smallint",
-                            "double precision",
-                            "numeric",
-                        ]:
-                            values.append(str(column.value))
-                        elif column.data_type in ["bit", "bit varying"]:
-                            values.append(str(f"b'{column.value}'"))
-                        else:
-                            values.append(str(f"'{column.value}'"))
-
-                    columns = '"' + '", "'.join([column.name for column in row]) + '"'
-                    file.write(f"INSERT INTO {table.name} ({columns}) VALUES ({', '.join(values)});\n")
+                    file.write(f"{self.insert_statement(table, row)}\n")
             return name
-        return ""
+        if output["type"] == "file" and self.file_path is not None:
+            with self.lock, open(self.file_path, "a") as file:
+                for row in rows:
+                    file.write(f"{self.insert_statement(table, row)}\n")
+            return os.path.basename(self.file_path)
+        return None

--- a/redactdump/core/models.py
+++ b/redactdump/core/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Union
+from typing import Any, List
 
 
 @dataclass
@@ -10,7 +10,7 @@ class TableColumn:
     data_type: str
     is_nullable: bool
     default: str
-    value: Union[str, None] = None
+    value: Any = None
 
 
 @dataclass

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,0 +1,84 @@
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Optional
+
+from rich.console import Console
+
+from redactdump.core.file import File
+from redactdump.core.models import Table, TableColumn
+
+
+def build_config(location: Path, naming: Optional[str] = None) -> dict:
+    """Build a minimal single-file output config."""
+    output: dict = {"type": "file", "location": str(location)}
+    if naming is not None:
+        output["naming"] = naming
+    return {"debug": {"enabled": False}, "output": output}
+
+
+def sample_rows() -> list:
+    """Return a single row with a numeric and a string column."""
+    return [
+        [
+            TableColumn("id", "integer", False, "", 1),
+            TableColumn("name", "character varying", True, "", "Alice"),
+        ]
+    ]
+
+
+def test_single_file_output(tmp_path: Path) -> None:
+    """All rows are written as INSERT statements into one file."""
+    file = File(build_config(tmp_path / "dump"), Console())
+    name = file.write_to_file(Table("users", []), sample_rows())
+
+    content = (tmp_path / "dump.sql").read_text()
+    assert name == "dump.sql"
+    assert content == 'INSERT INTO users ("id", "name") VALUES (1, \'Alice\');\n'
+
+
+def test_single_file_truncated_on_init(tmp_path: Path) -> None:
+    """An existing target file is emptied when a run starts."""
+    target = tmp_path / "dump.sql"
+    target.write_text("STALE DATA\n")
+
+    File(build_config(tmp_path / "dump"), Console())
+
+    assert target.read_text() == ""
+
+
+def test_single_file_naming_template(tmp_path: Path) -> None:
+    """The naming template is applied with table_name dropped and no stray separators."""
+    file = File(build_config(tmp_path / "dump", naming="export-[table_name]-[timestamp]"), Console())
+    file.write_to_file(Table("users", []), sample_rows())
+
+    files = list(tmp_path.glob("*.sql"))
+    assert len(files) == 1
+    name = files[0].name
+    assert files[0].parent == tmp_path
+    assert name.startswith("export-") and name.endswith(".sql")
+    assert "[table_name]" not in name and "[timestamp]" not in name
+    assert "--" not in name
+
+
+def test_resolve_file_path_drops_table_name_cleanly() -> None:
+    """table_name is dropped for any template ordering without leaving stray separators."""
+    for naming in ["dump-[table_name]-[timestamp]", "[table_name]-[timestamp]", "dump-[timestamp]-[table_name]"]:
+        path = File.resolve_file_path({"location": "out/db", "naming": naming})
+        stem = path[len("out/") : -len(".sql")]
+        assert "[table_name]" not in stem
+        assert not stem.startswith(("-", "_")) and not stem.endswith(("-", "_"))
+        assert "--" not in stem
+
+
+def test_single_file_concurrent_writes(tmp_path: Path) -> None:
+    """Concurrent writes from many threads never interleave a line."""
+    file = File(build_config(tmp_path / "dump"), Console())
+    table = Table("events", [])
+    rows = [[TableColumn("id", "integer", False, "", i)] for i in range(200)]
+
+    with ThreadPoolExecutor(max_workers=8) as exe:
+        list(exe.map(lambda row: file.write_to_file(table, [row]), rows))
+
+    lines = (tmp_path / "dump.sql").read_text().splitlines()
+    assert len(lines) == 200
+    assert all(line.startswith("INSERT INTO events") and line.endswith(");") for line in lines)


### PR DESCRIPTION
Closes #5.

Implements `output.type: file` so every table is dumped into one `.sql` file.

- Resolve the single-file path once at init; truncate it at the start of each run.
- Serialize concurrent writes from the worker threads with a lock.
- Apply the naming template (`[timestamp]` substituted, `[table_name]` dropped).
- Extract a shared `insert_statement` helper for both output types.
- Add tests for write, truncation, naming, and concurrency.