### PR TITLE
Add explicit casts for PostgreSQL data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,24 +152,6 @@ INSERT INTO table_name VALUES (99, 'Robin Jefferson');
 
 </details>
 
-## Known limitations
+## Data types
 
-### Data types not supported
-
-* box
-* bytea
-* inet
-* interval
-* circle
-* cidr
-* line
-* lseg
-* macaddr
-* macaddr8
-* pg_lsn
-* pg_snapshot
-* point
-* polygon
-* tsquery
-* tsvector
-* txid_snapshot
+PostgreSQL-specific types (`inet`, `cidr`, `macaddr`, `macaddr8`, `interval`, `point`, `line`, `lseg`, `box`, `circle`, `polygon`, `tsvector`, `tsquery`, `pg_lsn`, `pg_snapshot`, `txid_snapshot`) are exported with an explicit `::type` cast, and `bytea` is exported as a hex literal. Redacting one of these columns requires a replacement that produces a value valid for the type.

--- a/redactdump/core/file.py
+++ b/redactdump/core/file.py
@@ -8,6 +8,29 @@ from rich.console import Console
 
 from redactdump.core.models import Table, TableColumn
 
+NUMERIC_TYPES = frozenset({"bigint", "integer", "smallint", "double precision", "numeric"})
+BIT_TYPES = frozenset({"bit", "bit varying"})
+CAST_TYPES = frozenset(
+    {
+        "box",
+        "cidr",
+        "circle",
+        "inet",
+        "interval",
+        "line",
+        "lseg",
+        "macaddr",
+        "macaddr8",
+        "pg_lsn",
+        "pg_snapshot",
+        "point",
+        "polygon",
+        "tsquery",
+        "tsvector",
+        "txid_snapshot",
+    }
+)
+
 
 class File:
     """File class."""
@@ -99,6 +122,34 @@ class File:
         return name
 
     @staticmethod
+    def format_value(column: TableColumn) -> str:
+        """Render a column value as a PostgreSQL literal.
+
+        PostgreSQL-specific types are emitted with an explicit ::type cast so the
+        value is unambiguous, and bytea is rendered as a hex literal.
+
+        Args:
+            column (TableColumn): Column with its value and data type.
+
+        Returns:
+            str: The SQL literal.
+        """
+        value = column.value
+        data_type = column.data_type
+        if value is None:
+            return "NULL"
+        if data_type in NUMERIC_TYPES:
+            return str(value)
+        if data_type in BIT_TYPES:
+            return f"b'{value}'"
+        if data_type == "bytea" and isinstance(value, (bytes, bytearray, memoryview)):
+            return f"'\\x{bytes(value).hex()}'::bytea"
+        literal = str(value).replace("'", "''")
+        if data_type in CAST_TYPES:
+            return f"'{literal}'::{data_type}"
+        return f"'{literal}'"
+
+    @staticmethod
     def insert_statement(table: Table, row: List[TableColumn]) -> str:
         """Build an INSERT statement for a single row.
 
@@ -109,16 +160,8 @@ class File:
         Returns:
             str: The INSERT statement.
         """
-        values = []
-        for column in row:
-            if column.data_type in ["bigint", "integer", "smallint", "double precision", "numeric"]:
-                values.append(str(column.value))
-            elif column.data_type in ["bit", "bit varying"]:
-                values.append(f"b'{column.value}'")
-            else:
-                values.append(f"'{column.value}'")
-
-        columns = '"' + '", "'.join([column.name for column in row]) + '"'
+        values = [File.format_value(column) for column in row]
+        columns = ", ".join(f'"{column.name}"' for column in row)
         return f"INSERT INTO {table.name} ({columns}) VALUES ({', '.join(values)});"
 
     def write_to_file(self, table: Table, rows: List[List[TableColumn]]) -> Union[str, None]:

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -60,6 +60,63 @@ def test_single_file_naming_template(tmp_path: Path) -> None:
     assert "--" not in name
 
 
+def column(data_type: str, value: object) -> TableColumn:
+    """Build a column with the given data type and value."""
+    return TableColumn("c", data_type, True, "", value)
+
+
+def test_format_value_numeric_is_unquoted() -> None:
+    """Numeric types are emitted without quotes or casts."""
+    assert File.format_value(column("integer", 5)) == "5"
+    assert File.format_value(column("numeric", "1.50")) == "1.50"
+
+
+def test_format_value_bit() -> None:
+    """Bit strings keep the b'...' form."""
+    assert File.format_value(column("bit", "101")) == "b'101'"
+
+
+def test_format_value_plain_string_is_quoted() -> None:
+    """Unlisted types fall back to a plain quoted literal."""
+    assert File.format_value(column("character varying", "Alice")) == "'Alice'"
+
+
+def test_format_value_pg_types_get_explicit_cast() -> None:
+    """PostgreSQL-specific types are emitted with an explicit ::type cast."""
+    assert File.format_value(column("inet", "192.168.0.1")) == "'192.168.0.1'::inet"
+    assert File.format_value(column("point", "(1,2)")) == "'(1,2)'::point"
+    assert File.format_value(column("macaddr8", "08:00:2b:01:02:03:04:05")) == "'08:00:2b:01:02:03:04:05'::macaddr8"
+
+
+def test_format_value_bytea_is_hex_literal() -> None:
+    """Binary bytea values are rendered as a hex literal."""
+    assert File.format_value(column("bytea", memoryview(b"\xde\xad\xbe\xef"))) == "'\\xdeadbeef'::bytea"
+    assert File.format_value(column("bytea", b"\x01\x02")) == "'\\x0102'::bytea"
+
+
+def test_format_value_none_is_null() -> None:
+    """A None value becomes a SQL NULL for any type, not a quoted literal."""
+    assert File.format_value(column("character varying", None)) == "NULL"
+    assert File.format_value(column("inet", None)) == "NULL"
+    assert File.format_value(column("bytea", None)) == "NULL"
+
+
+def test_format_value_escapes_single_quotes() -> None:
+    """Single quotes in string and cast values are doubled."""
+    assert File.format_value(column("character varying", "O'Brien")) == "'O''Brien'"
+    assert File.format_value(column("tsvector", "a'b")) == "'a''b'::tsvector"
+
+
+def test_write_to_file_emits_cast_in_insert(tmp_path: Path) -> None:
+    """A cast type is rendered inside the full INSERT line written to disk."""
+    file = File(build_config(tmp_path / "dump"), Console())
+    row = [TableColumn("ip", "inet", True, "", "192.168.0.1")]
+    file.write_to_file(Table("hosts", []), [row])
+
+    content = (tmp_path / "dump.sql").read_text()
+    assert content == "INSERT INTO hosts (\"ip\") VALUES ('192.168.0.1'::inet);\n"
+
+
 def test_resolve_file_path_drops_table_name_cleanly() -> None:
     """table_name is dropped for any template ordering without leaving stray separators."""
     for naming in ["dump-[table_name]-[timestamp]", "[table_name]-[timestamp]", "dump-[timestamp]-[table_name]"]:


### PR DESCRIPTION
Closes #16.

The PG-specific types that were emitted as bare quoted strings are now rendered as typed literals in `File.format_value`:

- `inet`, `cidr`, `macaddr`, `macaddr8`, `interval`, `point`, `line`, `lseg`, `box`, `circle`, `polygon`, `tsvector`, `tsquery`, `pg_lsn`, `pg_snapshot`, `txid_snapshot` get an explicit `::type` cast.
- `bytea` is rendered as a `'\xHEX'::bytea` literal (same form as `pg_dump`; assumes `standard_conforming_strings = on`).
- `None` now becomes `NULL`, and single quotes in values are escaped.

Verified against a live PostgreSQL 14 that `information_schema.data_type` reports these by name and that the generated literals round-trip on INSERT. Tests cover each path; ruff/ty clean.